### PR TITLE
refactor: simplify `createEnterprisePlan` logic and update CTA behavior

### DIFF
--- a/apps/web/components/marketing/price/components/pricing-content.tsx
+++ b/apps/web/components/marketing/price/components/pricing-content.tsx
@@ -61,9 +61,7 @@ export function PricingContent({ title, description, yearlyDiscount, propPlans, 
         )
       : propPlans || []
 
-  const enterprisePlan = createEnterprisePlan(isAuthenticated, (planName, seats) =>
-    handleUpgradeSubscription(planName, seats, isYearly)
-  )
+  const enterprisePlan = createEnterprisePlan()
 
   return (
     <>

--- a/apps/web/components/marketing/price/utils/plan-utils.tsx
+++ b/apps/web/components/marketing/price/utils/plan-utils.tsx
@@ -84,10 +84,7 @@ export function transformApiPlanToPlan(
   }
 }
 
-export function createEnterprisePlan(
-  isAuthenticated: boolean,
-  handleUpgradeSubscription: (planName: string, seats: number) => Promise<void>
-): Plan {
+export function createEnterprisePlan(): Plan {
   return {
     id: 'enterprise',
     name: 'Enterprise',
@@ -96,14 +93,10 @@ export function createEnterprisePlan(
     monthlyPrice: 0,
     yearlyPrice: 0,
     seats: -1,
-    cta: isAuthenticated ? {
+    cta: {
       variant: 'glow' as const,
       label: 'Contact Us',
-      onClick: () => handleUpgradeSubscription('Enterprise', -1)
-    } : {
-      variant: 'glow' as const,
-      label: 'Contact Us',
-      href: '/login'
+      href: 'mailto:contact@libra.dev'
     },
     features: [
       'All Premium features',


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Simplified the `createEnterprisePlan` function and updated the Enterprise plan CTA to open an email to contact support instead of redirecting to login.

- **Refactors**
  - Removed unnecessary parameters and logic from `createEnterprisePlan`.
  - CTA now uses a mailto link for direct contact.

<!-- End of auto-generated description by cubic. -->

