### PR TITLE
chore: disable GitHub Actions deploy workflow in favor of Cloudflare …

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,47 +1,60 @@
+# DISABLED: Using Cloudflare Workers build instead of GitHub Actions
+# This workflow has been disabled as the project now uses Cloudflare Workers for deployment
+# To re-enable, uncomment the push and pull_request triggers below
+
 name: 'Libra Web Core Deploy'
 
 on:
+  # Manual trigger only - automatic deployment is handled by Cloudflare Workers
   workflow_dispatch:
-  push:
-    branches: [ main ]
-    paths:
-      - 'apps/web/**'
-      - 'packages/api/**'
-      - 'packages/auth/**'
-      - 'packages/better-auth-cloudflare/**'
-      - 'packages/better-auth-stripe/**'
-      - 'packages/common/**'
-      - 'packages/db/**'
-      - 'packages/email/**'
-      - 'packages/templates/**'
-      - 'packages/ui/**'
-      - 'packages/shikicode/**'
-      - 'packages/sandbox/**'
-      - 'tooling/**'
-      - 'package.json'
-      - 'turbo.json'
-      - '.github/workflows/web.yml'
-      - 'bun.lock'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'apps/web/**'
-      - 'packages/api/**'
-      - 'packages/auth/**'
-      - 'packages/better-auth-cloudflare/**'
-      - 'packages/better-auth-stripe/**'
-      - 'packages/common/**'
-      - 'packages/db/**'
-      - 'packages/email/**'
-      - 'packages/templates/**'
-      - 'packages/ui/**'
-      - 'packages/shikicode/**'
-      - 'packages/sandbox/**'
-      - 'tooling/**'
-      - 'package.json'
-      - 'turbo.json'
-      - '.github/workflows/web.yml'
-      - 'bun.lock'
+    inputs:
+      force_deploy:
+        description: 'Force manual deployment (emergency only)'
+        required: false
+        default: false
+        type: boolean
+
+  # Disabled automatic triggers - uncomment if needed
+  # push:
+  #   branches: [ main ]
+  #   paths:
+  #     - 'apps/web/**'
+  #     - 'packages/api/**'
+  #     - 'packages/auth/**'
+  #     - 'packages/better-auth-cloudflare/**'
+  #     - 'packages/better-auth-stripe/**'
+  #     - 'packages/common/**'
+  #     - 'packages/db/**'
+  #     - 'packages/email/**'
+  #     - 'packages/templates/**'
+  #     - 'packages/ui/**'
+  #     - 'packages/shikicode/**'
+  #     - 'packages/sandbox/**'
+  #     - 'tooling/**'
+  #     - 'package.json'
+  #     - 'turbo.json'
+  #     - '.github/workflows/web.yml'
+  #     - 'bun.lock'
+  # pull_request:
+  #   branches: [ main ]
+  #   paths:
+  #     - 'apps/web/**'
+  #     - 'packages/api/**'
+  #     - 'packages/auth/**'
+  #     - 'packages/better-auth-cloudflare/**'
+  #     - 'packages/better-auth-stripe/**'
+  #     - 'packages/common/**'
+  #     - 'packages/db/**'
+  #     - 'packages/email/**'
+  #     - 'packages/templates/**'
+  #     - 'packages/ui/**'
+  #     - 'packages/shikicode/**'
+  #     - 'packages/sandbox/**'
+  #     - 'tooling/**'
+  #     - 'package.json'
+  #     - 'turbo.json'
+  #     - '.github/workflows/web.yml'
+  #     - 'bun.lock'
 
 # Limit concurrent workflow runs
 concurrency:

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Libra is built entirely on Cloudflare. You need to be familiar with the followin
 | [Queues](https://developers.cloudflare.com/queues/?utm_source=libra.dev) | Message queue service | Asynchronous task processing and batch deployment management |
 | [AI Gateway](https://developers.cloudflare.com/ai-gateway/?utm_source=libra.dev) | AI model gateway | Monitor and control your AI applications |
 | [Images](https://developers.cloudflare.com/images/?utm_source=libra.dev) | Image processing optimization | Dynamic image transformation and CDN distribution |
+| [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/?utm_source=libra.dev) | Built-in CI/CD for Workers | Use Cloudflare’s native Workers Builds to continuously build and deploy from your repo, or integrate external CI providers (e.g., GitHub Actions) to run tests, build, and deploy via Wrangler.|
 
 Libra adopts **Turborepo** Monorepo architecture design:
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -159,6 +159,8 @@ Libra 完全构建于 Cloudflare 上。你需要对以下产品熟悉：
 | [Queues](https://developers.cloudflare.com/queues/?utm_source=libra.dev) | 消息队列服务 | 异步任务处理和批量部署管理 |
 | [AI Gateway](https://developers.cloudflare.com/ai-gateway/?utm_source=libra.dev) | AI 模型网关 | 监控和控制你的 AI 应用|
 | [Images](https://developers.cloudflare.com/images/?utm_source=libra.dev) | 图像处理优化 | 动态图像变换和 CDN 分发 |
+| [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/?utm_source=libra.dev) | Built-in CI/CD for Workers | Use Cloudflare’s native Workers Builds to continuously build and deploy from your repo, or integrate external CI providers (e.g., GitHub Actions) to run tests, build, and deploy via Wrangler.|
+
 
 Libra 采用 **Turborepo** Monorepo 架构设计：
 


### PR DESCRIPTION
…Workers deployment
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Disabled the GitHub Actions deploy workflow since deployments are now handled by Cloudflare Workers. The workflow can now only be triggered manually if needed.

<!-- End of auto-generated description by cubic. -->

