### PR TITLE
chore: bump versions and update dependencies

### DIFF
--- a/apps/builder/CHANGELOG.md
+++ b/apps/builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vite-shadcn-builder-libra
 
+## 1.0.2
+
+### Patch Changes
+
+- update deps
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-shadcn-builder-libra",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -42,11 +42,11 @@
     "sonner": "^2.0.7",
     "input-otp": "^1.4.2",
     "@splinetool/react-spline": "^4.1.0",
-    "react-router-dom": "^7.7.1",
+    "react-router-dom": "^7.8.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.15",
     "@hookform/resolvers": "^5.2.1",
-    "hono": "^4.8.12",
+    "hono": "^4.9.0",
     "@tanstack/react-query": "^5.84.1",
     "recharts": "^2.15.4",
     "vaul": "^1.1.2",
@@ -69,7 +69,7 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.9.2",
     "vite": "^6.3.5",
-    "@cloudflare/vite-plugin": "^1.11.1",
+    "@cloudflare/vite-plugin": "^1.11.2",
     "wrangler": "4.27.0",
     "@cloudflare/workers-types": "^4.20250807.0"
   }

--- a/apps/cdn/CHANGELOG.md
+++ b/apps/cdn/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @libra/cdn
 
+## 1.0.1
+
+### Patch Changes
+
+- update deps
+
 ## 1.0.0
 
 ### Major Changes

--- a/apps/cdn/package.json
+++ b/apps/cdn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libra/cdn",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "dev": "wrangler dev --port 3004 --persist-to=../web/.wrangler/state",
     "deploy": "wrangler deploy --minify",
@@ -13,7 +13,7 @@
     "@libra/db": "*",
     "@libra/middleware": "*",
     "@libra/typescript-config": "*",
-    "hono": "^4.8.12",
+    "hono": "^4.9.0",
     "@scalar/hono-api-reference": "^0.9.13",
     "@hono/zod-openapi": "^0.19.10"
   },

--- a/apps/deploy-workflow/CHANGELOG.md
+++ b/apps/deploy-workflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @libra/deploy-workflow
 
+## 1.0.1
+
+### Patch Changes
+
+- update deps
+
 ## 1.0.0
 
 ### Major Changes

--- a/apps/deploy-workflow/package.json
+++ b/apps/deploy-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libra/deploy-workflow",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "scripts": {
     "dev": "wrangler dev --port 3008 --persist-to=../web/.wrangler/state",
     "deploy": "wrangler deploy --minify",
@@ -16,7 +16,7 @@
     "@libra/sandbox": "*",
     "@libra/templates": "*",
     "@libra/typescript-config": "*",
-    "hono": "^4.8.12",
+    "hono": "^4.9.0",
     "@scalar/hono-api-reference": "^0.9.13",
     "@hono/zod-openapi": "^0.19.10"
   },

--- a/apps/deploy/CHANGELOG.md
+++ b/apps/deploy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @libra/deploy
 
+## 1.0.2
+
+### Patch Changes
+
+- update deps
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/deploy/package.json
+++ b/apps/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libra/deploy",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Queue-based deployment service for Libra platform",
   "scripts": {
     "dev": "wrangler dev --port 3008 --persist-to=../web/.wrangler/state",
@@ -20,7 +20,7 @@
     "@libra/sandbox": "*",
     "@libra/templates": "*",
     "@libra/typescript-config": "*",
-    "hono": "^4.8.12",
+    "hono": "^4.9.0",
     "@scalar/hono-api-reference": "^0.9.13",
     "@hono/zod-openapi": "^0.19.10",
     "zod": "^4.0.15",

--- a/apps/dispatcher/CHANGELOG.md
+++ b/apps/dispatcher/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @libra/dispatcher
 
+## 1.0.2
+
+### Patch Changes
+
+- update deps
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/dispatcher/package.json
+++ b/apps/dispatcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libra/dispatcher",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "wrangler dev --port 3007 --persist-to=../web/.wrangler/state",
@@ -15,7 +15,7 @@
     "@libra/db": "*",
     "@libra/common": "*",
     "@libra/middleware": "*",
-    "hono": "^4.8.12",
+    "hono": "^4.9.0",
     "pg": "^8.16.3",
     "zod": "^4.0.15",
     "@hono/zod-openapi": "^0.19.10",

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @libra/docs
 
+## 1.0.2
+
+### Patch Changes
+
+- update deps
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libra/docs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "build": "next build",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "fumadocs-core": "^15.6.9",
-    "fumadocs-mdx": "^11.7.3",
+    "fumadocs-mdx": "^11.7.4",
     "fumadocs-ui": "^15.6.9",
     "motion": "^12.23.12",
     "octokit": "^5.0.3",

--- a/apps/screenshot/CHANGELOG.md
+++ b/apps/screenshot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @libra/screenshot
 
+## 1.0.2
+
+### Patch Changes
+
+- update deps
+
 ## 1.0.1
 
 ### Patch Changes

--- a/apps/screenshot/package.json
+++ b/apps/screenshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libra/screenshot",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Queue-based screenshot service for Libra platform",
   "scripts": {
     "dev": "wrangler dev --port 3009 --persist-to=../web/.wrangler/state",
@@ -21,7 +21,7 @@
     "@libra/sandbox": "*",
     "@libra/templates": "*",
     "@libra/typescript-config": "*",
-    "hono": "^4.8.12",
+    "hono": "^4.9.0",
     "@scalar/hono-api-reference": "^0.9.13",
     "@hono/zod-openapi": "^0.19.10",
     "zod": "^4.0.15",

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # libra-core
 
+## 1.0.5
+
+### Patch Changes
+
+- update deps
+
 ## 1.0.4
 
 ### Patch Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libra-core",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "type": "module",
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.1",
-    "@ai-sdk/azure": "^2.0.4",
+    "@ai-sdk/azure": "^2.0.5",
     "@ai-sdk/xai": "^2.0.2",
     "@git-diff-view/file": "^0.0.30",
     "@git-diff-view/react": "^0.0.30",
@@ -44,14 +44,14 @@
     "@libra/ui": "*",
     "@lottiefiles/dotlottie-react": "^0.13.5",
     "@marsidev/react-turnstile": "^1.3.0",
-    "@openrouter/ai-sdk-provider": "^1.0.0-beta.7",
+    "@openrouter/ai-sdk-provider": "^1.1.0",
     "@shikijs/transformers": "^3.9.2",
     "@tanstack/react-query": "^5.84.1",
     "@tanstack/react-table": "^8.21.3",
     "@tsparticles/engine": "^3.9.1",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.9.1",
-    "ai": "^5.0.5",
+    "ai": "^5.0.8",
     "date-fns": "^4.1.0",
     "diff": "^8.0.2",
     "fast-xml-parser": "^5.2.5",

--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "apps/builder": {
       "name": "vite-shadcn-builder-libra",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.1",
         "@radix-ui/react-accordion": "^1.2.11",
@@ -71,7 +71,7 @@
         "class-variance-authority": "^0.7.1",
         "cmdk": "^0.2.1",
         "embla-carousel-react": "^8.6.0",
-        "hono": "^4.8.12",
+        "hono": "^4.9.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.486.0",
         "motion": "^12.23.12",
@@ -80,7 +80,7 @@
         "react-day-picker": "^9.8.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.62.0",
-        "react-router-dom": "^7.7.1",
+        "react-router-dom": "^7.8.0",
         "recharts": "^2.15.4",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
@@ -89,7 +89,7 @@
         "zod": "^4.0.15",
       },
       "devDependencies": {
-        "@cloudflare/vite-plugin": "^1.11.1",
+        "@cloudflare/vite-plugin": "^1.11.2",
         "@cloudflare/workers-types": "^4.20250807.0",
         "@tailwindcss/vite": "^4.1.11",
         "@types/node": "^22.17.0",
@@ -117,7 +117,7 @@
         "@libra/middleware": "*",
         "@libra/typescript-config": "*",
         "@scalar/hono-api-reference": "^0.9.13",
-        "hono": "^4.8.12",
+        "hono": "^4.9.0",
       },
       "devDependencies": {
         "wrangler": "4.27.0",
@@ -137,7 +137,7 @@
         "@libra/typescript-config": "*",
         "@scalar/hono-api-reference": "^0.9.13",
         "drizzle-orm": "^0.44.4",
-        "hono": "^4.8.12",
+        "hono": "^4.9.0",
         "zod": "^4.0.15",
       },
       "devDependencies": {
@@ -161,7 +161,7 @@
         "@libra/templates": "*",
         "@libra/typescript-config": "*",
         "@scalar/hono-api-reference": "^0.9.13",
-        "hono": "^4.8.12",
+        "hono": "^4.9.0",
       },
       "devDependencies": {
         "wrangler": "4.27.0",
@@ -169,7 +169,7 @@
     },
     "apps/dispatcher": {
       "name": "@libra/dispatcher",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@hono/zod-openapi": "^0.19.10",
         "@libra/common": "*",
@@ -177,7 +177,7 @@
         "@libra/middleware": "*",
         "@scalar/hono-api-reference": "^0.9.13",
         "drizzle-orm": "^0.44.4",
-        "hono": "^4.8.12",
+        "hono": "^4.9.0",
         "pg": "^8.16.3",
         "zod": "^4.0.15",
       },
@@ -197,7 +197,7 @@
         "@orama/orama": "^3.1.11",
         "@orama/tokenizers": "^3.1.11",
         "fumadocs-core": "^15.6.9",
-        "fumadocs-mdx": "^11.7.3",
+        "fumadocs-mdx": "^11.7.4",
         "fumadocs-ui": "^15.6.9",
         "motion": "^12.23.12",
         "octokit": "^5.0.3",
@@ -245,7 +245,7 @@
         "@libra/typescript-config": "*",
         "@scalar/hono-api-reference": "^0.9.13",
         "drizzle-orm": "^0.44.4",
-        "hono": "^4.8.12",
+        "hono": "^4.9.0",
         "zod": "^4.0.15",
       },
       "devDependencies": {
@@ -327,10 +327,10 @@
     },
     "apps/web": {
       "name": "libra-core",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.1",
-        "@ai-sdk/azure": "^2.0.4",
+        "@ai-sdk/azure": "^2.0.5",
         "@ai-sdk/xai": "^2.0.2",
         "@git-diff-view/file": "^0.0.30",
         "@git-diff-view/react": "^0.0.30",
@@ -348,14 +348,14 @@
         "@libra/ui": "*",
         "@lottiefiles/dotlottie-react": "^0.13.5",
         "@marsidev/react-turnstile": "^1.3.0",
-        "@openrouter/ai-sdk-provider": "^1.0.0-beta.7",
+        "@openrouter/ai-sdk-provider": "^1.1.0",
         "@shikijs/transformers": "^3.9.2",
         "@tanstack/react-query": "^5.84.1",
         "@tanstack/react-table": "^8.21.3",
         "@tsparticles/engine": "^3.9.1",
         "@tsparticles/react": "^3.0.0",
         "@tsparticles/slim": "^3.9.1",
-        "ai": "^5.0.5",
+        "ai": "^5.0.8",
         "date-fns": "^4.1.0",
         "diff": "^8.0.2",
         "fast-xml-parser": "^5.2.5",
@@ -421,7 +421,7 @@
     },
     "packages/better-auth-cloudflare": {
       "name": "@libra/better-auth-cloudflare",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "better-auth": "^1.3.4",
       },
@@ -504,7 +504,7 @@
     },
     "packages/sandbox": {
       "name": "@libra/sandbox",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@daytonaio/sdk": "^0.25.5",
         "@libra/common": "*",
@@ -583,11 +583,11 @@
   "packages": {
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@2.0.1", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-HtNbpNV9qXQosHu00+CBMEcdTerwZY+kpVMNak0xP/P5TF6XkPf7IyizhLuc7y5zcXMjZCMA7jDGkcEdZCEdkw=="],
 
-    "@ai-sdk/azure": ["@ai-sdk/azure@2.0.4", "", { "dependencies": { "@ai-sdk/openai": "2.0.4", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-Y5XRfTDeS+llG0yQ0B1Vx3A8hu5icJbcfBIQftacYSpeEY4XtiiXTGHURGG4RxX+71VEWmHOhd6oTIoAoI5Ijw=="],
+    "@ai-sdk/azure": ["@ai-sdk/azure@2.0.5", "", { "dependencies": { "@ai-sdk/openai": "2.0.5", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-IR2SWV0/zeNiJY2PxrjfTe/MQo6TFPEmZPv6zKZ1ZLQANBYoUYbDUAY2XLH2T1qZ/Gcc+V2WAahmb5rAd3n/0A=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.3", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-QRGz2vH1WR9NvCv8gWocoebAKiXcuqj22mug6i8COeVsp33x5K5cK2DT4TwiQx5SfYbqJbVoBT+UqnHF7A3PHA=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.4", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-1roLdgMbFU3Nr4MC97/te7w6OqxsWBkDUkpbCcvxF3jz/ku91WVaJldn/PKU8feMKNyI5W9wnqhbjb1BqbExOQ=="],
 
-    "@ai-sdk/openai": ["@ai-sdk/openai@2.0.4", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-PnVUFosX2zWk6emiX4SulZrGvGw79YJjh/DgxahpAcBpz71GlQyzVNTFAQx7ycFGLBg/YniJr1M2WJybYZZ3ug=="],
+    "@ai-sdk/openai": ["@ai-sdk/openai@2.0.5", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-1oFXNudUNRfl4QXlE2Q0v8GCvGngx8HMwHN6pyOTMBP8SI9VoOcCJzRPVBMLd0SI7dkcAvGVkpSVTnaLaXEtxQ=="],
 
     "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.2", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-VqTEzo1ueUsS9FGHtyoAHK11nPIgtziwwGGy5qtGOs+JRcZVEdPqcWe1n2+Ichl4edchoAHo/tygAymaiom9mg=="],
 
@@ -873,7 +873,7 @@
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.5.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.19", "workerd": "^1.20250722.0" }, "optionalPeers": ["workerd"] }, "sha512-CZe9B2VbjIQjBTyc+KoZcN1oUcm4T6GgCXoel9O7647djHuSRAa6sM6G+NdxWArATZgeMMbsvn9C50GCcnIatA=="],
 
-    "@cloudflare/vite-plugin": ["@cloudflare/vite-plugin@1.11.1", "", { "dependencies": { "@cloudflare/unenv-preset": "2.6.0", "@mjackson/node-fetch-server": "^0.6.1", "@rollup/plugin-replace": "^6.0.1", "get-port": "^7.1.0", "miniflare": "4.20250803.0", "picocolors": "^1.1.1", "tinyglobby": "^0.2.12", "unenv": "2.0.0-rc.19", "wrangler": "4.28.0", "ws": "8.18.0" }, "peerDependencies": { "vite": "^6.1.0 || ^7.0.0" } }, "sha512-ITVdyIE2yhw63gQqabpDGu4AdZ50t0bBuN8b89niJ24UaXox/TLm2WTp5aupaBEvkjxt4OVJ+Dn5bytJfS60Ow=="],
+    "@cloudflare/vite-plugin": ["@cloudflare/vite-plugin@1.11.2", "", { "dependencies": { "@cloudflare/unenv-preset": "2.6.0", "@mjackson/node-fetch-server": "^0.6.1", "@rollup/plugin-replace": "^6.0.1", "get-port": "^7.1.0", "miniflare": "4.20250803.0", "picocolors": "^1.1.1", "tinyglobby": "^0.2.12", "unenv": "2.0.0-rc.19", "wrangler": "4.28.1", "ws": "8.18.0" }, "peerDependencies": { "vite": "^6.1.0 || ^7.0.0" } }, "sha512-iY/XTYE3TCZLXaIYGljGQeG81XmUkQ2ZOqzVs56a+5QQyxkA9S8sqfBh/FX0vwzUASLFVUru0WsyqCB4fxrSAA=="],
 
     "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250730.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-X3egNyTjLQaECYe34x8Al7r4oXAhcN3a8+8qcpNCcq1sgtuHIeAwS9potgRR/mwkGfmrJn7nfAyDKC4vrkniQQ=="],
 
@@ -1241,7 +1241,7 @@
 
     "@opennextjs/cloudflare": ["@opennextjs/cloudflare@1.6.5", "", { "dependencies": { "@dotenvx/dotenvx": "1.31.0", "@opennextjs/aws": "3.7.4", "cloudflare": "^4.4.1", "enquirer": "^2.4.1", "glob": "^11.0.0", "ts-tqdm": "^0.8.6", "yargs": "^18.0.0" }, "peerDependencies": { "wrangler": "^4.24.4" }, "bin": { "opennextjs-cloudflare": "dist/cli/index.js" } }, "sha512-eOoRrslJW/cK5RotFHA8Se/KlKyynOFA29i9jor4cp1JF/AkGSwatUaBNK0oLvqM4nDCq3Bo/HlYRbyc/R/T0w=="],
 
-    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@1.0.0-beta.7", "", { "peerDependencies": { "ai": "^5.0.0-beta.12", "zod": "^3.24.1 || ^v4" } }, "sha512-DDCaOBLHX52lxa0FhLT/CpREAt6sbq21n9HZHFRRs8r4G2/tH3bgfcUfy5Dq6IN3xsGtCJuA50i2hL25ffzsow=="],
+    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@1.1.0", "", { "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-e5cW/KbgGakHOOsDhnHI6a0IDul9ER5J4QGM4yN9EfQ8XHfOFgwGGpLOopoRwkqaX5UdyQrpzei+1DPzg95i0A=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -2023,7 +2023,7 @@
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
-    "ai": ["ai@5.0.5", "", { "dependencies": { "@ai-sdk/gateway": "1.0.3", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-NPQ8Yv4lR7o/1rM+HQ0JT18zKxVFy/DrFDpvxlBQqmemSwsf3FlLNTK0asWXo9YtDAc0BOFL/y4kB56Hffi4yg=="],
+    "ai": ["ai@5.0.8", "", { "dependencies": { "@ai-sdk/gateway": "1.0.4", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.1", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-qbnhj046UvG30V1S5WhjBn+RBGEAmi8PSZWqMhRsE3EPxvO5BcePXTZFA23e9MYyWS9zr4Vm8Mv3wQXwLmtIBw=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -2559,7 +2559,7 @@
 
     "fumadocs-core": ["fumadocs-core@15.6.9", "", { "dependencies": { "@formatjs/intl-localematcher": "^0.6.1", "@orama/orama": "^3.1.11", "@shikijs/rehype": "^3.9.2", "@shikijs/transformers": "^3.9.2", "github-slugger": "^2.0.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "image-size": "^2.0.2", "negotiator": "^1.0.0", "npm-to-yarn": "^3.0.1", "react-remove-scroll": "^2.7.1", "remark": "^15.0.0", "remark-gfm": "^4.0.1", "remark-rehype": "^11.1.2", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^3.9.2", "unist-util-visit": "^5.0.0" }, "peerDependencies": { "@mixedbread/sdk": "^0.19.0", "@oramacloud/client": "1.x.x || 2.x.x", "@types/react": "*", "algoliasearch": "5.x.x", "next": "14.x.x || 15.x.x", "react": "18.x.x || 19.x.x", "react-dom": "18.x.x || 19.x.x", "react-router": "7.x.x" }, "optionalPeers": ["@mixedbread/sdk", "@oramacloud/client", "@types/react", "algoliasearch", "next", "react", "react-dom", "react-router"] }, "sha512-GVrJ2C2fch3KfNz3utqvF2CeZ7Uc947lfo7Deq1mKhWlH+HY3RSUM9MMecRl+uTzu9TNWPCUwj9q0XSUBh5VbQ=="],
 
-    "fumadocs-mdx": ["fumadocs-mdx@11.7.3", "", { "dependencies": { "@mdx-js/mdx": "^3.1.0", "@standard-schema/spec": "^1.0.0", "chokidar": "^4.0.3", "esbuild": "^0.25.8", "estree-util-value-to-estree": "^3.4.0", "js-yaml": "^4.1.0", "lru-cache": "^11.1.0", "picocolors": "^1.1.1", "tinyexec": "^1.0.1", "tinyglobby": "^0.2.14", "unist-util-visit": "^5.0.0", "zod": "^4.0.14" }, "peerDependencies": { "@fumadocs/mdx-remote": "^1.4.0", "fumadocs-core": "^14.0.0 || ^15.0.0", "next": "^15.3.0", "react": "*", "vite": "6.x.x || 7.x.x" }, "optionalPeers": ["@fumadocs/mdx-remote", "next", "react", "vite"], "bin": { "fumadocs-mdx": "bin.js" } }, "sha512-EMuISWaUeImpd2KI9LdWfc1rMWv9qfIoJSAXsI3TDXph8v4FyQ7Nz+NRpeoNgv59gzwKbkMRcnZnrKXI/ybnoA=="],
+    "fumadocs-mdx": ["fumadocs-mdx@11.7.4", "", { "dependencies": { "@mdx-js/mdx": "^3.1.0", "@standard-schema/spec": "^1.0.0", "chokidar": "^4.0.3", "esbuild": "^0.25.8", "estree-util-value-to-estree": "^3.4.0", "js-yaml": "^4.1.0", "lru-cache": "^11.1.0", "picocolors": "^1.1.1", "tinyexec": "^1.0.1", "tinyglobby": "^0.2.14", "unist-util-visit": "^5.0.0", "zod": "^4.0.15" }, "peerDependencies": { "@fumadocs/mdx-remote": "^1.4.0", "fumadocs-core": "^14.0.0 || ^15.0.0", "next": "^15.3.0", "react": "*", "vite": "6.x.x || 7.x.x" }, "optionalPeers": ["@fumadocs/mdx-remote", "next", "react", "vite"], "bin": { "fumadocs-mdx": "bin.js" } }, "sha512-PNn3AcbaDJwAaXlm5lgVG4CavWOPWVH9FNaB1L0BsKMthnprDlagDy54+8QX3EAzeUB2eLYTtrD3BIjzbzpFEg=="],
 
     "fumadocs-ui": ["fumadocs-ui@15.6.9", "", { "dependencies": { "@radix-ui/react-accordion": "^1.2.11", "@radix-ui/react-collapsible": "^1.1.11", "@radix-ui/react-dialog": "^1.1.14", "@radix-ui/react-direction": "^1.1.1", "@radix-ui/react-navigation-menu": "^1.2.13", "@radix-ui/react-popover": "^1.1.14", "@radix-ui/react-presence": "^1.1.4", "@radix-ui/react-scroll-area": "^1.2.9", "@radix-ui/react-slot": "^1.2.3", "@radix-ui/react-tabs": "^1.1.12", "class-variance-authority": "^0.7.1", "fumadocs-core": "15.6.9", "lodash.merge": "^4.6.2", "next-themes": "^0.4.6", "postcss-selector-parser": "^7.1.0", "react-medium-image-zoom": "^5.3.0", "scroll-into-view-if-needed": "^3.1.0", "tailwind-merge": "^3.3.1" }, "peerDependencies": { "@types/react": "*", "next": "14.x.x || 15.x.x", "react": "18.x.x || 19.x.x", "react-dom": "18.x.x || 19.x.x", "tailwindcss": "^3.4.14 || ^4.0.0" }, "optionalPeers": ["@types/react", "next", "tailwindcss"] }, "sha512-4zQcWqBJx7DuJn3IWAVrRY7o7Xx6DsScq3U8R8Qu2EJOuioJHotyLoVldSaB3wLioxtR7ito6866LZDp3oci6A=="],
 
@@ -2641,7 +2641,7 @@
 
     "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
 
-    "hono": ["hono@4.8.12", "", {}, "sha512-MQSKk1Mg7b74k8l+A025LfysnLtXDKkE4pLaSsYRQC5iy85lgZnuyeQ1Wynair9mmECzoLu+FtJtqNZSoogBDQ=="],
+    "hono": ["hono@4.9.0", "", {}, "sha512-JAUc4Sqi3lhby2imRL/67LMcJFKiCu7ZKghM7iwvltVZzxEC5bVJCsAa4NTnSfmWGb+N2eOVtFE586R+K3fejA=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
@@ -3349,7 +3349,7 @@
 
     "react-router": ["react-router@7.7.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-jVKHXoWRIsD/qS6lvGveckwb862EekvapdHJN/cGmzw40KnJH5gg53ujOJ4qX6EKIK9LSBfFed/xiQ5yeXNrUA=="],
 
-    "react-router-dom": ["react-router-dom@7.7.1", "", { "dependencies": { "react-router": "7.7.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-bavdk2BA5r3MYalGKZ01u8PGuDBloQmzpBZVhDLrOOv1N943Wq6dcM9GhB3x8b7AbqPMEezauv4PeGkAJfy7FQ=="],
+    "react-router-dom": ["react-router-dom@7.8.0", "", { "dependencies": { "react-router": "7.8.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-ntInsnDVnVRdtSu6ODmTQ41cbluak/ENeTif7GBce0L6eztFg6/e1hXAysFQI8X25C8ipKmT9cClbJwxx3Kaqw=="],
 
     "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
 
@@ -4093,7 +4093,7 @@
 
     "@cloudflare/vite-plugin/miniflare": ["miniflare@4.20250803.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "sharp": "^0.33.5", "stoppable": "1.1.0", "undici": "^7.10.0", "workerd": "1.20250803.0", "ws": "8.18.0", "youch": "4.1.0-beta.10", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-1tmCLfmMw0SqRBF9PPII9CVLQRzOrO7uIBmSng8BMSmtgs2kos7OeoM0sg6KbR9FrvP/zAniLyZuCAMAjuu4fQ=="],
 
-    "@cloudflare/vite-plugin/wrangler": ["wrangler@4.28.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.6.0", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250803.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.19", "workerd": "1.20250803.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250803.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-y0yHIuScpok9oSErLqDbxkBChC2+/jZpvqMg2NxOto1JCyUtDUuKljOfcVMaI48d9GuhOCSoWSumYxLAHNxaLA=="],
+    "@cloudflare/vite-plugin/wrangler": ["wrangler@4.28.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.6.0", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250803.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.19", "workerd": "1.20250803.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250803.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-B1w6XS3o1q1Icyx1CyirY5GNyYhucd63Jqml/EYSbB5dgv0VT8ir7L8IkCdbICEa4yYTETIgvTTZqffM6tBulA=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
@@ -4339,8 +4339,6 @@
 
     "fumadocs-mdx/tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
 
-    "fumadocs-mdx/zod": ["zod@4.0.14", "", {}, "sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw=="],
-
     "fumadocs-ui/tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
     "get-source/data-uri-to-buffer": ["data-uri-to-buffer@2.0.2", "", {}, "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="],
@@ -4427,6 +4425,8 @@
 
     "react-error-boundary/@babel/runtime": ["@babel/runtime@7.28.2", "", {}, "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA=="],
 
+    "react-router-dom/react-router": ["react-router@7.8.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg=="],
+
     "react-transition-group/@babel/runtime": ["@babel/runtime@7.28.2", "", {}, "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA=="],
 
     "read-cache/pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
@@ -4493,7 +4493,7 @@
 
     "vite-shadcn-template-libra/tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
-    "vite-shadcn-template-libra/wrangler": ["wrangler@4.28.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.6.0", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250803.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.19", "workerd": "1.20250803.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250803.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-y0yHIuScpok9oSErLqDbxkBChC2+/jZpvqMg2NxOto1JCyUtDUuKljOfcVMaI48d9GuhOCSoWSumYxLAHNxaLA=="],
+    "vite-shadcn-template-libra/wrangler": ["wrangler@4.28.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.0", "@cloudflare/unenv-preset": "2.6.0", "blake3-wasm": "2.1.5", "esbuild": "0.25.4", "miniflare": "4.20250803.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.19", "workerd": "1.20250803.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250803.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-B1w6XS3o1q1Icyx1CyirY5GNyYhucd63Jqml/EYSbB5dgv0VT8ir7L8IkCdbICEa4yYTETIgvTTZqffM6tBulA=="],
 
     "webpack/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated package versions and dependencies across all apps to include the latest patches and minor releases.

- **Dependencies**
  - Bumped versions for hono, react-router-dom, ai, fumadocs-mdx, @cloudflare/vite-plugin, and other packages in each app.
  - Updated bun.lock to reflect new dependency versions.

<!-- End of auto-generated description by cubic. -->

