### PR TITLE
chore: remove outdated `updatedAt` field updates and refine FREE plan…

### DIFF
--- a/apps/cdn/src/utils/quota-management.ts
+++ b/apps/cdn/src/utils/quota-management.ts
@@ -104,6 +104,7 @@ async function attemptPaidPlanUploadDeduction(
             .update(subscriptionLimit)
             .set({
                 uploadLimit: sql<number>`(${subscriptionLimit.uploadLimit}) - 1`,
+                updatedAt: sql`CURRENT_TIMESTAMP`,
             })
             .where(
                 and(
@@ -245,6 +246,7 @@ async function handleFreePlanUploadDeduction(
                         // projectNums: keep existing value, don't reset
                         periodStart: newPeriodStart.toISOString(),
                         periodEnd: nextPeriodEnd.toISOString(),
+                        updatedAt: sql`CURRENT_TIMESTAMP`,
                     })
                     .where(eq(subscriptionLimit.id, freeLimit.id))
 
@@ -475,6 +477,7 @@ export async function restoreUploadQuotaOnDeletion(c: AppContext): Promise<{
                         .update(subscriptionLimit)
                         .set({
                             uploadLimit: sql<number>`(${subscriptionLimit.uploadLimit}) + 1`,
+                            updatedAt: sql`CURRENT_TIMESTAMP`,
                         })
                         .where(
                             and(

--- a/packages/auth/utils/subscription-limits/core.ts
+++ b/packages/auth/utils/subscription-limits/core.ts
@@ -1122,7 +1122,7 @@ async function handleFreePlanProjectDeduction(
 
         // Refresh the FREE plan with new quota and immediately deduct 1 for this request
         // This ensures the refresh operation is immediately successful
-        // Note: For project quota, we increment existing projectNums by 1 (user is creating a new project)
+        // Note: projectNums represents remaining quota, so we refresh to default then deduct 1
         await tx
           .update(subscriptionLimit)
           .set({
@@ -1131,7 +1131,7 @@ async function handleFreePlanProjectDeduction(
             uploadLimit: freePlanLimits.aiNums,
             deployLimit: freePlanLimits.aiNums * 2,
             seats: freePlanLimits.seats,
-            projectNums: freeLimit.projectNums + 1, // Increment existing count by 1 (new project)
+            projectNums: freePlanLimits.projectNums - 1, // Refresh quota and deduct 1 for current project creation
             periodStart: newPeriodStart.toISOString(),
             periodEnd: nextPeriodEnd.toISOString(),
           })
@@ -1139,7 +1139,7 @@ async function handleFreePlanProjectDeduction(
 
         log.subscription('info', 'FREE plan refreshed and project deducted', {
           organizationId,
-          remaining: freePlanLimits.projectNums - 1,
+          newProjectNums: freePlanLimits.projectNums - 1,
           operation: 'project_usage_deduction'
         })
         return true // Refresh and deduction completed successfully

--- a/packages/auth/utils/subscription-limits/core.ts
+++ b/packages/auth/utils/subscription-limits/core.ts
@@ -142,6 +142,7 @@ export async function createOrUpdateSubscriptionLimit(
           seats: limits.seats,
           periodStart: utcPeriodStart.toISOString(),
           periodEnd: utcPeriodEnd.toISOString(),
+          updatedAt: sql`CURRENT_TIMESTAMP`,
         })
         .where(eq(subscriptionLimit.id, existingActiveRecord.id))
 
@@ -182,7 +183,7 @@ export async function createOrUpdateSubscriptionLimit(
       // First deactivate existing paid plans
       await tx
         .update(subscriptionLimit)
-        .set({ isActive: false })
+        .set({ isActive: false, updatedAt: sql`CURRENT_TIMESTAMP` })
         .where(
           and(
             eq(subscriptionLimit.organizationId, organizationId),
@@ -293,6 +294,7 @@ async function attemptPaidPlanDeduction(
       .update(subscriptionLimit)
       .set({
         aiNums: sql<number>`(${subscriptionLimit.aiNums}) - 1`,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
       })
       .where(
         and(
@@ -345,6 +347,7 @@ async function attemptPaidPlanEnhanceDeduction(
       .update(subscriptionLimit)
       .set({
         enhanceNums: sql<number>`(${subscriptionLimit.enhanceNums}) - 1`,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
       })
       .where(
         and(
@@ -714,6 +717,7 @@ export async function getSubscriptionUsage(organizationId: string): Promise<Subs
           // projectNums: keep existing value, don't reset
           periodStart: newPeriodStart.toISOString(),
           periodEnd: nextPeriodEnd.toISOString(),
+          updatedAt: sql`CURRENT_TIMESTAMP`,
         })
         .where(eq(subscriptionLimit.id, freeLimit.id))
 
@@ -992,6 +996,7 @@ async function attemptPaidPlanProjectDeduction(
       .update(subscriptionLimit)
       .set({
         projectNums: sql<number>`(${subscriptionLimit.projectNums}) - 1`,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
       })
       .where(
         and(
@@ -1601,6 +1606,7 @@ async function attemptPaidPlanDeployDeduction(
       .update(subscriptionLimit)
       .set({
         deployLimit: sql<number>`(${subscriptionLimit.deployLimit}) - 1`,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
       })
       .where(
         and(


### PR DESCRIPTION
… refresh logic in quota management

- Remove unnecessary `updatedAt` updates; rely on Drizzle's `$onUpdate` mechanism.
- Refine FREE plan quota refresh logic to preserve `projectNums` value and streamline period calculations.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Simplified quota updates by removing manual updatedAt writes and made FREE plan refresh safer and more accurate. FREE plan now keeps projectNums on refresh, resets only quotas, and auto-refreshes on usage reads when expired.

- **Bug Fixes**
  - Preserve projectNums on FREE plan refresh; on new project, increment existing count instead of resetting.
  - Auto-refresh expired FREE plan in getSubscriptionUsage, with UTC-aligned monthly periods.
  - Keep refresh-and-deduct flow atomic for FREE actions (AI, enhance, upload, project).

- **Refactors**
  - Removed all manual updatedAt updates; rely on Drizzle $onUpdate.
  - Standardized FREE plan quota reset fields; stop resetting projectNums.
  - Dropped updatedAt writes when deactivating paid plans and during quota deductions.

<!-- End of auto-generated description by cubic. -->

